### PR TITLE
Convert relative links to perma-links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These guides include information on when and why to practice PSIP, how to kick
 off the process, how to set goals, and more.
 
 If you are brand-new to PSIP, we recommend you begin with
-[Why practice PSIP?](/practice-guides/pages/why_practice_PSIP.html) to learn more about it and
+[Why practice PSIP?](https://bssw-psip.github.io/practice-guides/pages/why_practice_PSIP.html) to learn more about it and
 what it can do for your scientific software development team. Learn more about
 how to apply it by going through the following steps (as see below in the
 contents).
@@ -22,13 +22,13 @@ contents).
 
 ## Contents
 
-- [Why practice PSIP?](/practice-guides/pages/why_practice_PSIP.html)
-- [How to get started](/practice-guides/pages/how_to_start.html)
-- [How to set goals](/practice-guides/pages/how_to_set_goals.html)
-- [How to create PTCs](/practice-guides/pages/how_to_create_ptc.html)
-  (Want to give back? [Share your PTC.](/ptc-catalog/pages/how-to-contribute.html))
-- [How to execute your improvement plan](/practice-guides/pages/how_to_execute_plan.html)
-- [How to assess progress](/practice-guides/pages/how_to_assess_progress.html)
+- [Why practice PSIP?](https://bssw-psip.github.io/practice-guides/pages/why_practice_PSIP.html)
+- [How to get started](https://bssw-psip.github.io/practice-guides/pages/how_to_start.html)
+- [How to set goals](https://bssw-psip.github.io/practice-guides/pages/how_to_set_goals.html)
+- [How to create PTCs](https://bssw-psip.github.io/practice-guides/pages/how_to_create_ptc.html)
+  (Want to give back? [Share your PTC.](https://bssw-psip.github.io/ptc-catalog/pages/how-to-contribute.html))
+- [How to execute your improvement plan](https://bssw-psip.github.io/practice-guides/pages/how_to_execute_plan.html)
+- [How to assess progress](https://bssw-psip.github.io/practice-guides/pages/how_to_assess_progress.html)
 
 ### Acknowledgement
 

--- a/pages/how_to_assess_progress.md
+++ b/pages/how_to_assess_progress.md
@@ -1,6 +1,6 @@
 # Assessing Your Progress
 
-<a href="/practice-guides/pages/how_to_execute_plan.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Go Back to Steps 5 & 6</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/how_to_execute_plan.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Go Back to Steps 5 & 6</a>
 
 You are ready to assess your progress and repeat the process as needed.
 
@@ -28,24 +28,24 @@ The PSIP process is cyclical. Iterate as often as you need to.
 Introduce new PTCs. Modify existing ones. Elevate your processes.
 Upgrade your team practices.
 
-We've talked about [Why Practice PSIP?](/practice-guides/pages/why_practice_PSIP.html).
+We've talked about [Why Practice PSIP?](https://bssw-psip.github.io/practice-guides/pages/why_practice_PSIP.html).
 Let's recap all of the steps:
 
-1. [Summarize Current Project Practices](/practice-guides/pages/how_to_start.html)
-2. [Set Goals](/practice-guides/pages/how_to_set_goals.html)
-3. [Construct Progress Tracking Card (PTC)](/practice-guides/pages/how_to_create_ptc.html)
-4. [Record Current PTC Values](/practice-guides/pages/how_to_create_ptc.html)
-5. [Create Plan for Increasing PTC Values](/practice-guides/pages/how_to_execute_plan.html)
-6. [Execute Plan](/practice-guides/pages/how_to_execute_plan.html)
-7. [Assess Progress](/practice-guides/pages/how_to_assess_progress.html)
+1. [Summarize Current Project Practices](https://bssw-psip.github.io/practice-guides/pages/how_to_start.html)
+2. [Set Goals](https://bssw-psip.github.io/practice-guides/pages/how_to_set_goals.html)
+3. [Construct Progress Tracking Card (PTC)](https://bssw-psip.github.io/practice-guides/pages/how_to_create_ptc.html)
+4. [Record Current PTC Values](https://bssw-psip.github.io/practice-guides/pages/how_to_create_ptc.html)
+5. [Create Plan for Increasing PTC Values](https://bssw-psip.github.io/practice-guides/pages/how_to_execute_plan.html)
+6. [Execute Plan](https://bssw-psip.github.io/practice-guides/pages/how_to_execute_plan.html)
+7. [Assess Progress](https://bssw-psip.github.io/practice-guides/pages/how_to_assess_progress.html)
 
 We encourage you to share your experience using PSIP and any artifacts
 that were created as a part of your process (e.g., PTCs). See our
-[Contributing Guide](/ptc-catalog/pages/how-to-contribute.html) for more information or chat with us on [Gitter](https://gitter.im/bssw-psip/community).
+[Contributing Guide](https://bssw-psip.github.io/ptc-catalog/pages/how-to-contribute.html) for more information or chat with us on [Gitter](https://gitter.im/bssw-psip/community).
 
 ### Resources
 - [Publication](https://www.osti.gov/biblio/1574620):
   _Lightweight Software Process Improvement using Productivity and Sustainability Improvement Planning (PSIP)_
-- [PTC Catalog](/ptc-catalog/)
+- [PTC Catalog](https://bssw-psip.github.io/ptc-catalog/)
 - [BSSw PSIP Page](https://bssw.io/psip)
 - [RateYourProject](https://rateyourproject.org)

--- a/pages/how_to_create_ptc.md
+++ b/pages/how_to_create_ptc.md
@@ -1,6 +1,6 @@
 # Creating and Assigning Values to Progress Tracking Cards
 
-<a href="/practice-guides/pages/how_to_set_goals.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Go Back to Step 2</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/how_to_set_goals.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Go Back to Step 2</a>
 
 You are now ready to create your first progress tracking card.
 
@@ -85,7 +85,7 @@ along the way to completion.
 
 ### Share your PTC
 
-We encourage you to [share your custom PTC](/ptc-catalog/pages/how-to-contribute.html) with the wider community. Please
+We encourage you to [share your custom PTC](https://bssw-psip.github.io/ptc-catalog/pages/how-to-contribute.html) with the wider community. Please
 consider contributing back to the PTC Catalog.
 
 ## Step 4: Record Current PTC Values
@@ -111,4 +111,4 @@ established or provide a link to the policy itself.
 
 Ready to move to the next step?
 
-<a href="/practice-guides/pages/how_to_execute_plan.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Steps 5 & 6: Create and Execute Plan</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/how_to_execute_plan.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Steps 5 & 6: Create and Execute Plan</a>

--- a/pages/how_to_execute_plan.md
+++ b/pages/how_to_execute_plan.md
@@ -1,6 +1,6 @@
 # Creating and Executing a Practice Improvement Plan
 
-<a href="/practice-guides/pages/how_to_create_ptc.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Go Back to Steps 3 & 4</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/how_to_create_ptc.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Go Back to Steps 3 & 4</a>
 
 
 You are now ready to create and execute your practice improvement plan.
@@ -23,7 +23,7 @@ step in which you want to define what actions must be taken. In the
 Creating your plan requires a bit of thought about your current project
 tracking techniques. You may use Kanban, Agile, or another. We suggest
 you integrate your PTCs with your project process. We have provided
-several examples in the [PTC Catalog](/ptc-catalog/pages/save-ptc-to-repository.html).
+several examples in the [PTC Catalog](https://bssw-psip.github.io/ptc-catalog/pages/save-ptc-to-repository.html).
 
 
 ## Step 6: Execute Plan
@@ -36,10 +36,10 @@ meetings, during a retrospective, or asynchronously. You may decide to execute y
 practice improvement plan a number of ways. You can attempt to incorporate
 complementary software process improvement methods that you already use to execute your plan!
 
-Take a look at [our examples](/ptc-catalog/pages/save-ptc-to-repository.html) for inspiration.
+Take a look at [our examples](https://bssw-psip.github.io/ptc-catalog/pages/save-ptc-to-repository.html) for inspiration.
 Feel free to customize our examples to fit your needs.
 
 
 Ready to move to the next step?
 
-<a href="/practice-guides/pages/how_to_assess_progress.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Step 7: Assess Progress</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/how_to_assess_progress.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Step 7: Assess Progress</a>

--- a/pages/how_to_set_goals.md
+++ b/pages/how_to_set_goals.md
@@ -1,6 +1,6 @@
 # Setting Goals for Your Project
 
-<a href="/practice-guides/pages/how_to_start.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Go Back to Step 1</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/how_to_start.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Go Back to Step 1</a>
 
 You may have noticed that the process of describing current practices
 has several benefits. For some, the exercise leads to the first concrete
@@ -44,5 +44,5 @@ establish baseline values and tangibly track progress as your practices improve.
 
 Ready to move to the next step?
 
-<a href="/practice-guides/pages/how_to_create_ptc.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Steps 3 & 4: Construct and Record PTC</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/how_to_create_ptc.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Steps 3 & 4: Construct and Record PTC</a>
 

--- a/pages/how_to_start.md
+++ b/pages/how_to_start.md
@@ -1,6 +1,6 @@
 # Getting Started with PSIP
 
-<a href="/practice-guides/pages/why_practice_PSIP.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Why Practice PSIP?</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/why_practice_PSIP.html"><img src="/practice-guides/assets/images/back_arrow.png" width="18" /> Why Practice PSIP?</a>
 
 
 As you already know, PSIP framework is an iterative, incremental, repeatable,
@@ -84,4 +84,4 @@ others, the following topics should be addressed:
 
 Ready to move to the next step?
 
-<a href="/practice-guides/pages/how_to_set_goals.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Step 2: Set Goals</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/how_to_set_goals.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Step 2: Set Goals</a>

--- a/pages/why_practice_PSIP.md
+++ b/pages/why_practice_PSIP.md
@@ -39,4 +39,4 @@ still recommend you practice PSIP to upgrade team practices anytime!
 
 Ready to get started?
 
-<a href="/practice-guides/pages/how_to_start.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Get Started</a>
+<a href="https://bssw-psip.github.io/practice-guides/pages/how_to_start.html"><img src="/practice-guides/assets/images/forward_arrow.png" width="18" /> Get Started</a>


### PR DESCRIPTION
## Fixes #7 

## Description

This changes the relative links that render correctly only on the website https://bssw-psip.github.io/practices-guides to URLs that are accessible both on the website and directly through the repository.